### PR TITLE
Added composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "zetagraph/monoset",
+    "description": "Drupal 8 Theme",
+    "type": "drupal-theme",
+    "homepage": "https://github.com/zetagraph",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Andrei Zvonkov",
+            "email": "zvonkov@gmail.com",
+            "role": "Maintainer"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {}
+}


### PR DESCRIPTION
@zetagraph 
Hi!
Please add composer.json to your repo as it allows us to install monoset and receive updates using composer.

For example, install drupal with dependencies:

    composer create-project drupal-composer/drupal-project:8.x-dev some-dir --stability dev --no-interaction && cd some-dir

Add monoset repo to repositories config:

    composer config repositories.monoset vcs https://github.com/zetagraph/monoset

Add monoset to require config and download it to themes/contrib:

    composer require zetagraph/monoset

Update monoset to the latest commit:

    composer update zetagraph/monoset

See more: 
[drupal repo](https://github.com/drupal-composer/drupal-project)
[full blown drupalcommerce profile](https://github.com/drupalcommerce/commerce)

I have a lot of ideas on your project so it would be much simpler to develop them with composer package manager.

(Кстати — классная тема!)
